### PR TITLE
Restrict Playwright browsers to Chromium

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,8 @@ jobs:
     - name: Install Playwright CLI (no manifest)
       run: dotnet tool install Microsoft.Playwright.CLI --tool-path tools
     
-    - name: Install Playwright browsers
-      run: tools/playwright install --with-deps
+    - name: Install Playwright browsers (Chromium only)
+      run: tools/playwright install --with-deps chromium
 
     - name: Generate and trust HTTPS development certificate
       run: |


### PR DESCRIPTION
This is an internal only application and the organisation enforces the use of Chrome